### PR TITLE
Changed to only HTTPS resources (fixes #1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,11 @@
         <link rel="stylesheet" type="text/css" href="css/elastislide.css" />
         <link rel="stylesheet" type="text/css" href="css/custom.css" />
         <script src="js/modernizr.custom.17475.js"></script>
-    <link rel="stylesheet" href="http://davidstutz.github.io/bootstrap-multiselect/dist/css/bootstrap-multiselect.css" type="text/css"/>
-    <!-- <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">-->
+    <link rel="stylesheet" href="https://davidstutz.github.io/bootstrap-multiselect/dist/css/bootstrap-multiselect.css" type="text/css"/>
+    <!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <!--  <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script> -->
-    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+    <!--  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script> -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
     <link href="https://d396qusza40orc.cloudfront.net/phoenixassets/web-frameworks/bootstrap-social.css" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="stylesheet" href="css/skills.css">
@@ -163,19 +163,6 @@
                                         <span id="typed" style="white-space:pre;color: #3aacc7;"></span>
                                         <br>    <span style="color:#1b6d85; font-weight: 800">Motivation</span> is the word I love and put into my work everyday.
                                     </div>
-
-                                    <script type="text/javascript">
-                                        var text = ["Web Development", "Software Development", "Machine Learning", "Data Science", "and more.."];
-                                        var counter = 0;
-                                        var elem = document.getElementById("changeText");
-                                        setInterval(change, 1500);
-                                        function change() {
-                                            elem.innerHTML = text[counter];
-                                            counter++;
-                                            if(counter >= text.length) { counter = 0; }
-                                        }
-
-                                    </script>
                                 </div>
                             </div>
                         </div>
@@ -777,7 +764,7 @@
 
 </script>
 
-<script type="text/javascript" src="http://davidstutz.github.io/bootstrap-multiselect/dist/js/bootstrap-multiselect.js"></script>
+<script type="text/javascript" src="https://davidstutz.github.io/bootstrap-multiselect/dist/js/bootstrap-multiselect.js"></script>
 <script type="text/javascript" src="js/jquerypp.custom.js"></script>
 <script type="text/javascript" src="js/jquery.elastislide.js"></script>
 <script type="text/javascript">

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
 </script>
     	<!-- meta charec set -->
         <meta charset="utf-8">
-		
+
         <title>Yash Mittra</title>
 	    <link rel="shortcut icon" href="image/logo1.png">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -18,11 +18,11 @@
 	    <link rel="stylesheet" type="text/css" href="css/elastislide.css" />
 		<link rel="stylesheet" type="text/css" href="css/custom.css" />
         <script src="js/modernizr.custom.17475.js"></script>
-       <link rel="stylesheet" href="http://davidstutz.github.io/bootstrap-multiselect/dist/css/bootstrap-multiselect.css" type="text/css"/>
-       <!-- <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">-->
+       <link rel="stylesheet" href="https://davidstutz.github.io/bootstrap-multiselect/dist/css/bootstrap-multiselect.css" type="text/css"/>
+       <!-- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">-->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-      <!--  <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script> -->
-        <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+      <!--  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script> -->
+        <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
         <link href="https://d396qusza40orc.cloudfront.net/phoenixassets/web-frameworks/bootstrap-social.css" rel="stylesheet">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
         <link rel="stylesheet" href="css/skills.css">
@@ -33,12 +33,12 @@
 <style>
 
 </style>
-        
-     
+
+
     </head>
-	
+
     <body >
-	
+
         <header id="navigation" class="navbar-fixed-top navbar ">
                 <div class="navbar-header">
                     <!-- responsive nav button -->
@@ -47,7 +47,7 @@
                         <i class="fa fa-bars fa-2x"></i>
                     </button>
 					<!-- /responsive nav button -->
-					
+
 					<!-- logo -->
 
 					<!-- /logo -->
@@ -114,7 +114,7 @@
                 </nav>
 				<!-- /main nav -->
 			        </header>
-        
+
 
         <div>
             <section class='page1' id="bgg">
@@ -696,7 +696,7 @@
 
 
 
-          
+
         <div class="footer-wrapper">
             <footer class="site-footer">
 
@@ -704,10 +704,10 @@
 
 			</footer><!-- .site-footer -->
 			</div>
-   
-    
+
+
    <!-- <script src="js/bootstrap.js"></script>-->
-      
+
        <script src="js/jquery.min.js"  type="text/javascript"></script>
 <!--<script src="js/bootstrap.min.js"  type="text/javascript"></script>-->
 		<!-- jquery easing -->
@@ -775,20 +775,20 @@ $(document).on('change', '.btn-file :file', function() {
 });
 
 </script>
-   
-    <script type="text/javascript" src="http://davidstutz.github.io/bootstrap-multiselect/dist/js/bootstrap-multiselect.js"></script>  
+
+    <script type="text/javascript" src="https://davidstutz.github.io/bootstrap-multiselect/dist/js/bootstrap-multiselect.js"></script>
     <script type="text/javascript" src="js/jquerypp.custom.js"></script>
 		<script type="text/javascript" src="js/jquery.elastislide.js"></script>
 		<script type="text/javascript">
-			
+
 			$( '#carousel' ).elastislide( {
 				minItems : 1
 			} );
 			$( '#carousel1' ).elastislide( {
 				minItems : 1
 			} );
-			
-		</script>  
+
+		</script>
 	 <script>
 $(function() {
     $('a[href*=#]:not([href=#])').click(function() {
@@ -802,7 +802,7 @@ $(function() {
         }
     });
 });
-</script> 
-        
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
When you a page loads over HTTPS, any scripts, css, or other files that are loading using an `http://...` URL will fail. 

One of the failing scripts was the multiselect script, which ended up affecting the typed script. This change should fix the problem! In the future, try to use HTTPS for everything, since there are no errors if you use `https://...` URLs in a HTTP page.